### PR TITLE
checks if url is substring of path for root items

### DIFF
--- a/menu_generator/menu.py
+++ b/menu_generator/menu.py
@@ -78,10 +78,20 @@ class MenuBase(object):
 
     def _is_selected(self, item_dict):
         """
-        Given a menu item dictionary, it returns true if `url` is on path.
+        Given a menu item dictionary, it returns true if `url` is on path,
+        unless the item is marked as a root, in which case returns true if `url` is part of path.
         """
         url = self._get_url(item_dict)
-        return url == self.path
+        if self._is_root(item_dict):
+            return url in self.path
+        else:
+            return url == self.path
+
+    def _is_root(self, item_dict):
+        """
+        Given a menu item dictionary, it returns true if item is marked as a `root`.
+        """
+        return item_dict.get('root', False)
 
     def _process_breadcrums(self, menu_list):
         """


### PR DESCRIPTION
I found it useful to have some items set to selected when their url matched part of the path, e.g. they were the root of a section with subsections accessible via on-page links rather than a main menu.

Maybe you'd like to add this as an option?
