### PR TITLE
Use simple_tag instead of assignment_tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ env:
   - DJANGO="django==1.10.7"
   - DJANGO="django==1.9.13"
   - DJANGO="django==1.8.18"
+  - DJANGO="django==2.0"
 
 install:
-  - pip install -r requirements.txt
+  - pip install $DJANGO
   - pip install flake8
   - pip install coveralls
 

--- a/menu_generator/templatetags/menu_generator.py
+++ b/menu_generator/templatetags/menu_generator.py
@@ -8,7 +8,7 @@ from ..menu import generate_menu
 register = template.Library()
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_menu(context, menu_name):
     """
     Returns a consumable menu list for a given menu_name found in settings.py.


### PR DESCRIPTION
The assignment_tag is depraceted and in django-2.0 removed.

Signed-off-by: Frantisek Lachman <lachmanfrantisek@gmail.com>