### PR TITLE
Stop processing validators after fail (#13)

### DIFF
--- a/menu_generator/menu.py
+++ b/menu_generator/menu.py
@@ -38,21 +38,19 @@ class MenuBase(object):
 
         if not isinstance(validators, (list, tuple)):
             raise ImproperlyConfigured("validators must be a list")
-
-        result_validations = []
+        
         for validator in validators:
             if isinstance(validator, tuple):
-                if len(validator) <= 1:
+                func_or_path, *args = validator
+                if not args:
                     raise ImproperlyConfigured("You are passing a tuple validator without args %s" % str(validator))
-                func = get_callable(validator[0])
-                # Using a python slice to get all items after the first to build function args
-                args = validator[1:]
-                # Pass the request as first arg by default
-                result_validations.append(func(self.request, *args))
             else:
-                func = get_callable(validator)
-                result_validations.append(func(self.request))  # pragma: no cover
-        return all(result_validations)
+                func_or_path, args = validator, []
+            
+            func = get_callable(func_or_path)
+            if not func(self.request, *args):
+                return False
+        return True
 
     def _has_attr(self, item_dict, attr):
         """

--- a/menu_generator/tests/test_menu.py
+++ b/menu_generator/tests/test_menu.py
@@ -190,6 +190,14 @@ class MenuTestCase(TestCase):
         self.menu.save_user_state(self.request)
         self.assertFalse(self.menu._is_validated(menu_dict))
 
+    def test_menu_multiple_validators_skip_on_false(self):
+        menu_dict = {
+            "validators": ["menu_generator.validators.is_staff", "this-is-never-evaluated"],
+        }
+        self.request.user = TestUser(authenticated=True)
+        self.menu.save_user_state(self.request)
+        self.assertFalse(self.menu._is_validated(menu_dict))
+
     def test_generate_menu_submenu_attribute_inheritance(self):
         self.request.user = TestUser(staff=True, authenticated=True, happy=True)
         self.menu.save_user_state(self.request)


### PR DESCRIPTION
Stop evaluating validators (which is unnecessary, may raise exceptions, etc) after the first failed validation. Resolves #13 