### PR TITLE
Avoid adding the same items multiple times into the same menu

### DIFF
--- a/menu_generator/templatetags/menu_generator.py
+++ b/menu_generator/templatetags/menu_generator.py
@@ -20,6 +20,8 @@ def get_menu(context, menu_name):
     :param menu_name: String, name of the menu to be found
     :return: Generated menu
     """
+    # Instantiate a new list() or else the same instance of the menu_list gets used over and over
+    # (and possibly re-adding the menu_from_apps list on each request)
     menu_list = list(getattr(settings, menu_name, defaults.MENU_NOT_FOUND))
     menu_from_apps = get_menu_from_apps(menu_name)
     # If there isn't a menu on settings but there is menu from apps we built menu from apps

--- a/menu_generator/templatetags/menu_generator.py
+++ b/menu_generator/templatetags/menu_generator.py
@@ -20,7 +20,7 @@ def get_menu(context, menu_name):
     :param menu_name: String, name of the menu to be found
     :return: Generated menu
     """
-    menu_list = getattr(settings, menu_name, defaults.MENU_NOT_FOUND)
+    menu_list = list(getattr(settings, menu_name, defaults.MENU_NOT_FOUND))
     menu_from_apps = get_menu_from_apps(menu_name)
     # If there isn't a menu on settings but there is menu from apps we built menu from apps
     if menu_list == defaults.MENU_NOT_FOUND and menu_from_apps:

--- a/menu_generator/tests/test_menu.py
+++ b/menu_generator/tests/test_menu.py
@@ -306,3 +306,13 @@ class MenuTestCase(TestCase):
         self.assertEqual(nav[0]["selected"], True)
         self.assertEqual(nav[0]["submenu"][0]["selected"], True)
         self.assertEqual(nav[0]["submenu"][1]["selected"], False)
+
+    def test_subsequent_requests(self):
+        self.request.user = TestUser(authenticated=True)
+        ctx = {
+            'request': self.request
+        }
+        nav1 = get_menu(ctx, 'NAV_MENU')
+        nav2 = get_menu(ctx, 'NAV_MENU')
+        # Both menus should be equal
+        self.assertEqual(nav1, nav2)


### PR DESCRIPTION
I have found the same items being added to the same submenu multiple times on each page refresh. This is a fix for that.