### PR TITLE
Implement related views

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@ Val Kneeman under the name [django-menuware](https://github.com/un33k/django-men
 
 ## Contributors:
 * Jonathan Weth - dev@jonathanweth.de
+* Dominik George - nik@naturalnet.de

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -9,3 +9,5 @@ Contributors
 ============
 
 `Jonathan Weth <https://github.com/hansegucker>`__ - dev@jonathanweth.de
+
+`Dominik George <https://www.openhub.net/accounts/Natureshadow>`__ - nik@naturalnet.de

--- a/docs/menugeneration.rst
+++ b/docs/menugeneration.rst
@@ -11,6 +11,7 @@ Django Menu Generator uses python dictionaries to represent the menu items, usua
         "url": URL spec,
         "root": True | False,
         "related_urls": [ list of related URLs ],
+        "related_views": [ list of related views ],
         "validators": [ list of validators ],
         "submenu": Dictionary like this
     }
@@ -24,6 +25,8 @@ Where each key is as follows:
 - ``url``: See :doc:`urls`
 
 - ``related_urls``: If one of this URLs is part of the path on the currently opened page, the menu item will be marked as selected (format of URLs like described at :doc:`urls`)
+
+  - ``related_views``: If the currently opened page resolves to one of these views, the menu item will be marked as selected.
 
 - ``root``: A flag to indicate this item is the root of a path, with this you can correctly mark nested menus as selected.
 

--- a/menu_generator/tests/test_menu.py
+++ b/menu_generator/tests/test_menu.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.test import TestCase
 
+from .urls import testview
 from .utils import TestUser, is_main_site, is_paid_user
 from ..menu import MenuBase
 from ..templatetags.menu_generator import get_menu
@@ -296,6 +297,51 @@ class MenuTestCase(TestCase):
                         "name": "child2",
                         "url": 'named_url',
                         "related_urls": ["/groups/"]
+                    },
+                ],
+            }
+        ]
+        nav = self.menu.generate_menu(list_dict)
+
+        self.assertEqual(len(nav), 1)
+        self.assertEqual(nav[0]["selected"], True)
+        self.assertEqual(nav[0]["submenu"][0]["selected"], True)
+        self.assertEqual(nav[0]["submenu"][1]["selected"], False)
+
+    def test_generate_menu_selected_related_views_simple(self):
+        self.request.user = TestUser(authenticated=True)
+        self.request.path = "/known-view/"
+        self.menu.save_user_state(self.request)
+        list_dict = [
+            {
+                "name": "parent1",
+                "url": "/user/account/",
+                "related_views": [testview],
+            }
+        ]
+        nav = self.menu.generate_menu(list_dict)
+
+        self.assertEqual(len(nav), 1)
+        self.assertEqual(nav[0]["selected"], True)
+
+    def test_generate_menu_selected_related_views_submenu(self):
+        self.request.user = TestUser(authenticated=True)
+        self.request.path = "/known-view/"
+        self.menu.save_user_state(self.request)
+        list_dict = [
+            {
+                "name": "parent1",
+                "url": "/user/account/",
+                "submenu": [
+                    {
+                        "name": "child1",
+                        "url": '/user/account/profile/',
+                        "related_views": [testview]
+                    },
+                    {
+                        "name": "child2",
+                        "url": 'named_url',
+                        "related_views": []
                     },
                 ],
             }

--- a/menu_generator/tests/urls.py
+++ b/menu_generator/tests/urls.py
@@ -1,7 +1,11 @@
 from django.conf.urls import url
 
+def testview(request):
+    return 'foo'
+
 urlpatterns = [
-    url('', lambda: 'foo'),
-    url('named-url', lambda: 'foo', name='named_url'),
-    url('named-with-params/(?P<pk>\d+)/', lambda: 'foo', name='named_with_params')
+    url(r'named-url', lambda: 'foo', name='named_url'),
+    url(r'named-with-params/(?P<pk>\d+)/', lambda: 'foo', name='named_with_params'),
+    url(r'known-view', testview, name='known_view'),
+    url(r'', lambda: 'foo'),
 ]


### PR DESCRIPTION
This implements a `related_views` attribute similar to `related_urls`. It takes a list of views instead of URL names or paths, so that views that take non-optional arguments can be matched without hard-coding URL snippets.

It is also guaranteed to work all the time and match unambiguously, because it matches in the reverse direction of `related_urls` — it looks at the current request, which yielded a view, and compares that very view to the list.

I consider this far more useful than the `related_urls` approach because the latter more or less enforces anti-patterns, but of course I do not mind having `related_urls` as well.