### PR TITLE
directly selecting a node with submenu

### DIFF
--- a/menu_generator/menu.py
+++ b/menu_generator/menu.py
@@ -114,7 +114,7 @@ class MenuBase(object):
         can be used as breadcrumbs
         """
         for item in menu_list:
-            if item['submenu']:
+            if not item['selected'] and item['submenu']:
                 item['selected'] = self._process_breadcrums(item['submenu'])
             if item['selected']:
                 return True


### PR DESCRIPTION
A
-> A.1
-> A.2

Selecting a menu item with a submenu (A) will always call _process_breadcrums() on all submenu items (A.1, A.2)
If non of the submenu items is selected, the parent node is also not selected.

Selecting A.1 will work and select A.
Directly selecting A will not mark A as selcted, as neither A.1 nor A.2 are selected.

fixes https://github.com/LaLogiaDePython/django-menu-generator/issues/16